### PR TITLE
correct the PERIOD in comment from 0.5 to 0.1

### DIFF
--- a/gdbprof.py
+++ b/gdbprof.py
@@ -126,7 +126,7 @@ class ProfileBeginCommand(gdb.Command):
     """Profile an application against wall clock time.
 profile begin [PERIOD]
 PERIOD is the sampling interval in seconds.
-The default PERIOD is 0.5 seconds.
+The default PERIOD is 0.1 seconds.
     """
 
     def __init__(self):


### PR DESCRIPTION
in code, period is 0.1 by default, but 0.5 in comment.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>